### PR TITLE
Fix typo in reversestring example when using apple word

### DIFF
--- a/completed_exercises/reversestring/index.js
+++ b/completed_exercises/reversestring/index.js
@@ -2,7 +2,7 @@
 // Given a string, return a new string with the reversed
 // order of characters
 // --- Examples
-//   reverse('apple') === 'leppa'
+//   reverse('apple') === 'elppa'
 //   reverse('hello') === 'olleh'
 //   reverse('Greetings!') === '!sgniteerG'
 

--- a/exercises/reversestring/index.js
+++ b/exercises/reversestring/index.js
@@ -2,7 +2,7 @@
 // Given a string, return a new string with the reversed
 // order of characters
 // --- Examples
-//   reverse('apple') === 'leppa'
+//   reverse('apple') === 'elppa'
 //   reverse('hello') === 'olleh'
 //   reverse('Greetings!') === '!sgniteerG'
 


### PR DESCRIPTION
You have a little typo in the reversestring example when using "apple" word it should said "elppa" instead of "leppa", hope it helps :smiley: 