### PR TITLE
Fix typo in fib test description to match test assertion

### DIFF
--- a/exercises/fib/test.js
+++ b/exercises/fib/test.js
@@ -20,6 +20,6 @@ test('calculates correct fib value for 4', () => {
   expect(fib(4)).toEqual(3);
 });
 
-test('calculates correct fib value for 15', () => {
+test('calculates correct fib value for 39', () => {
   expect(fib(39)).toEqual(63245986);
 });


### PR DESCRIPTION
Hey, the test description didn't match the test assertion in the last `fib` test.