### PR TITLE
Fixed a typo at the reversestring exercise description

### DIFF
--- a/exercises/reversestring/index.js
+++ b/exercises/reversestring/index.js
@@ -2,7 +2,7 @@
 // Given a string, return a new string with the reversed
 // order of characters
 // --- Examples
-//   reverse('apple') === 'leppa'
+//   reverse('apple') === 'elppa'
 //   reverse('hello') === 'olleh'
 //   reverse('Greetings!') === '!sgniteerG'
 


### PR DESCRIPTION
Fixed a typo at the reversestring exercise description ("apple" -> "elppa").