### PR TITLE
fix incorrect import in exercises/weave/weave/test.js

### DIFF
--- a/exercises/weave/test.js
+++ b/exercises/weave/test.js
@@ -1,5 +1,5 @@
 const weave = require('./index');
-const Queue = require('./Queue');
+const Queue = require('./queue');
 
 test('queues have a peek function', () => {
   const q = new Queue();


### PR DESCRIPTION
It should be import('queue') and not import('Queue'), because file in which Queue class is container is queue.js and not Queue.js